### PR TITLE
feat: splash weighted pools

### DIFF
--- a/src/db/entities/LiquidityPoolState.ts
+++ b/src/db/entities/LiquidityPoolState.ts
@@ -20,6 +20,8 @@ export type PoolStateExtraData = {
   minAda: string;
   batcherFee: string;
   txHash: string;
+  weight0?: number;
+  weight1?: number;
 } & { [key in DatumParameterKey]?: string | number | undefined };
 
 @Entity({ name: 'liquidity_pool_states' })

--- a/src/dex/SplashAnalyzer.ts
+++ b/src/dex/SplashAnalyzer.ts
@@ -54,6 +54,10 @@ const ACTION_SWAP: string = '00';
 const MAX_INT: bigint = 9_223_372_036_854_775_807n;
 const BATCHER_FEE = 2_000_000n;
 const FEE_DENOMINATOR = 100_000;
+const SPLASH_WEIGHTED_POOL_SCRIPTS = [
+  'c5283689ea30e0920c50adf77345b5809c05c962cc111e0f1d2dbedb',
+  'f60fd1e70f4b9dfc09cdde8d7f7f1277de2694c82a516d7d3cc9e03e',
+];
 
 export class SplashAnalyzer extends BaseAmmDexAnalyzer {
   public startSlot: number = 116958314;
@@ -266,6 +270,10 @@ export class SplashAnalyzer extends BaseAmmDexAnalyzer {
             datumParameters[DatumParameterKey.RoyaltyB] ?? 0
           );
 
+          const isWeighted = SPLASH_WEIGHTED_POOL_SCRIPTS.includes(
+            addressDetails.paymentCredential?.hash || ''
+          );
+
           return LiquidityPoolState.make(
             Dex.Splash,
             output.toAddress,
@@ -295,6 +303,8 @@ export class SplashAnalyzer extends BaseAmmDexAnalyzer {
                 Number(datumParameters.RoyaltyFee ?? 0),
               feeDenominator: FEE_DENOMINATOR,
               minAda: 0n.toString(),
+              // Only support 1/4 weighted pools
+              ...(isWeighted ? { weight0: 1, weight1: 4 } : {}),
             }
           );
         } catch (e) {

--- a/tests/splash.test.ts
+++ b/tests/splash.test.ts
@@ -117,6 +117,8 @@ describe('Splash', () => {
     expect(pool.extra.feeNumerator).toEqual(
       expected.poolFeeNumX - expected.treasuryFee
     );
+    expect(pool.extra.weight0).toBeUndefined();
+    expect(pool.extra.weight1).toBeUndefined();
   });
 
   it('Can index cfmm v5 pools', async () => {
@@ -227,6 +229,8 @@ describe('Splash', () => {
     expect(pool.extra.feeNumerator).toEqual(
       expected.poolFeeNumX - expected.treasuryFee
     );
+    expect(pool.extra.weight0).toBeUndefined();
+    expect(pool.extra.weight1).toBeUndefined();
   });
 
   it('Can index cfmm v6 pools', async () => {
@@ -343,9 +347,11 @@ describe('Splash', () => {
     expect(pool.extra.feeNumerator).toEqual(
       expected.poolFeeNumX - expected.treasuryFee - expected.royaltyFee
     );
+    expect(pool.extra.weight0).toBeUndefined();
+    expect(pool.extra.weight1).toBeUndefined();
   });
 
-  it.only('Can index weighted pools v1', async () => {
+  it('Can index weighted pools v1', async () => {
     const expected = {
       poolType: 'weighted',
       id: '46b3cc854cd3ffaf57d5f4f08f4488af9086d6f0792d71437e14b7df.53504c4153485f4144415f4e4654',
@@ -449,9 +455,11 @@ describe('Splash', () => {
     expect(pool.extra.feeNumerator).toEqual(
       expected.poolFeeNumX - expected.treasuryFee
     );
+    expect(pool.extra.weight0).toEqual(1);
+    expect(pool.extra.weight1).toEqual(4);
   });
 
-  it.only('Can index weighted pools v2', async () => {
+  it('Can index weighted pools v2', async () => {
     const expected = {
       poolType: 'weighted',
       id: '7127cf43aa973d8940e4c9e77c12194d7a50f240642d4e7c59ec3c95.44474f4c445f4144415f4e4654',
@@ -554,6 +562,7 @@ describe('Splash', () => {
     expect(pool.extra.feeNumerator).toEqual(
       expected.poolFeeNumX - expected.treasuryFee
     );
+    expect(pool.extra.weight0).toEqual(1);
+    expect(pool.extra.weight1).toEqual(4);
   });
-  it.todo('Can index fee switch pools');
 });


### PR DESCRIPTION
 
This pull request introduces support for weighted liquidity pools in the Splash DEX, including updates to the data model, analysis logic, and test cases. The most significant changes involve adding new fields to represent pool weights, implementing logic to detect and handle weighted pools, and extending tests to validate these updates.

### Support for Weighted Pools

* Added optional `weight0` and `weight1` fields to the `PoolStateExtraData` type to store weights for weighted pools. (`src/db/entities/LiquidityPoolState.ts`, [src/db/entities/LiquidityPoolState.tsR23-R24](diffhunk://#diff-2565b7d7b314e0ab02ffb5fc1961b900784f8aacde0ee928f210309e146ffa88R23-R24))
* Introduced a constant `SPLASH_WEIGHTED_POOL_SCRIPTS` to identify weighted pool scripts and added logic in `SplashAnalyzer` to detect and process weighted pools. (`src/dex/SplashAnalyzer.ts`, [[1]](diffhunk://#diff-1f97a40295013e36491e0e546f5cea8388165ec50c8f65dfc6b7065544c3150eR57-R60) [[2]](diffhunk://#diff-1f97a40295013e36491e0e546f5cea8388165ec50c8f65dfc6b7065544c3150eR273-R276) [[3]](diffhunk://#diff-1f97a40295013e36491e0e546f5cea8388165ec50c8f65dfc6b7065544c3150eR306-R307)

### Test Enhancements

* Updated existing test cases to verify that the `weight0` and `weight1` fields remain undefined for non-weighted pools. (`tests/splash.test.ts`, [[1]](diffhunk://#diff-e140df95ebcee613ccc48861543cbd6ca5514df037849e8441477a3238361f53R120-R121) [[2]](diffhunk://#diff-e140df95ebcee613ccc48861543cbd6ca5514df037849e8441477a3238361f53R232-R233) [[3]](diffhunk://#diff-e140df95ebcee613ccc48861543cbd6ca5514df037849e8441477a3238361f53R350-R354)
* Added assertions to validate the correct weights (`weight0: 1`, `weight1: 4`) for weighted pools in new test cases. (`tests/splash.test.ts`, [[1]](diffhunk://#diff-e140df95ebcee613ccc48861543cbd6ca5514df037849e8441477a3238361f53R458-R462) [[2]](diffhunk://#diff-e140df95ebcee613ccc48861543cbd6ca5514df037849e8441477a3238361f53R565-L558)